### PR TITLE
Slider spacing

### DIFF
--- a/pyglui/design_params.pxi
+++ b/pyglui/design_params.pxi
@@ -31,9 +31,9 @@ DEF color_line_default = (1.,1.,1.,.4)
 DEF size_text_info = 18
 
 # Slider - design parameters
-DEF slider_outline_size_y = 60.
+DEF slider_outline_size_y = 65.
 DEF slider_label_org_y = 20.
-DEF slider_handle_org_y = 35.
+DEF slider_handle_org_y = 40.
 DEF slider_button_size = circle_button_size
 DEF slider_button_size_read_only = 15.
 DEF slider_button_size_selected = circle_button_size_selected


### PR DESCRIPTION
I think the current slider handle is too close to the slider label. I thought it would be better to add some 'room' to the slider UI. So i Increaseed the `slider_outline_size_y` and `slider_handle_org_y` by 5px.

See the image below for before and after.

Before      |  After
:-------------------------:|:-------------------------:
![slider_60_35](https://user-images.githubusercontent.com/17331040/34148943-f97209c8-e4d5-11e7-99f5-c251489012f3.jpg) |  ![slider__65_40](https://user-images.githubusercontent.com/17331040/34148944-f9a56d54-e4d5-11e7-86a1-9b25db93d159.jpg)


