### PR TITLE
Improve read-only button colors

### DIFF
--- a/pyglui/design_params.pxi
+++ b/pyglui/design_params.pxi
@@ -71,10 +71,10 @@ DEF button_outline_size_y = 44.
 DEF button_outline_padding = outline_padding
 DEF button_text_padding = 2.
 DEF button_default_color = color_default
-DEF button_read_only_color = color_on_read_only
+DEF button_read_only_color = (0.25, 0.25, 0.25, 0.75)
 DEF button_active_color = color_selected
 DEF button_default_text_color = color_text_default
-DEF button_read_only_text_color = color_text_read_only
+DEF button_read_only_text_color = (0.5, 0.5, 0.5, 0.75)
 DEF button_active_text_color = color_shadow
 
 # Thumb - design parameters


### PR DESCRIPTION
https://github.com/pupil-labs/pupil/pull/1972 has shown that the current colors for read-only buttons are not usable. This PR attempts to improve the colors.

Old colors
![Screenshot 2020-07-16 at 11 15 30](https://user-images.githubusercontent.com/168390/87944136-48e80f00-ca9f-11ea-8558-0a98d2658414.png)

New colors
![Screenshot 2020-07-20 at 15 36 12](https://user-images.githubusercontent.com/168390/87944157-52717700-ca9f-11ea-9722-716b251ea863.png)
