### PR TITLE
Fix text height on content-scaled displays

### DIFF
--- a/pyglui/ui_elements.pxi
+++ b/pyglui/ui_elements.pxi
@@ -1103,6 +1103,7 @@ cdef class Info_Text(UI_element):
         glfont.pop_state()
         self.text_area.design_size.y  = (height-self.text_area.org.y)/ui_scale
         self.outline.design_size.y = self.text_area.design_size.y+outline_padding*2
+        self.text_area.compute(self.outline)
         self.outline.compute(parent)
 
     cpdef precompute(self,FitBox parent):

--- a/pyglui/ui_elements.pxi
+++ b/pyglui/ui_elements.pxi
@@ -1110,13 +1110,12 @@ cdef class Info_Text(UI_element):
         self.outline.compute(parent)
         self.text_area.compute(self.outline)
         glfont.push_state()
-        glfont.set_size(self.text_size)
+        glfont.set_size(self.text_size*ui_scale)
         left_word, height = glfont.compute_breaking_text(self.text_area.org.x, self.text_area.org.y, self._text, self.text_area.size.x,self.max_height )
         glfont.pop_state()
         self.text_area.design_size.y  = (height-self.text_area.org.y)/ui_scale
         self.outline.design_size.y = self.text_area.design_size.y+outline_padding*2
         self.outline.compute(parent)
-
 
 ########## Thumb ##########
 


### PR DESCRIPTION
Previously, the text height computation did not take the content-scale into account. This caused UI layout issues on computers with content-scaled displays, e.g. Macs with Retina displays.