### PR TITLE
Fix build for glew 2.2

### DIFF
--- a/glew_pxd.py
+++ b/glew_pxd.py
@@ -169,6 +169,8 @@ cdef extern from "include_glew.h":
     ctypedef GLintptr GLvdpauSurfaceNV
     ctypedef long GLVULKANPROCNV
 
+    ctypedef void *GLeglImageOES  # GL_EXT_EGL_image_storage
+
     ctypedef void (__stdcall *GLDEBUGPROCAMD)(GLuint id, GLenum category, GLenum severity, GLsizei length, GLchar *message, GLvoid *userParam)
     ctypedef void (__stdcall *GLDEBUGPROCARB)(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, GLchar *message, GLvoid *userParam)
 


### PR DESCRIPTION
Fixes #116 

---

### Tested
- ✅ macOS 11.0 (Big Sur) with `glew 2.2` installed (via `brew`) - @romanroibu 
- ✅ Ubuntu 18.04 (Bionic) with `glew 2.0` installed (via `apt`) - @romanroibu 
